### PR TITLE
Add connection config for devicedb

### DIFF
--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -63,6 +63,12 @@ var_defs:
      value: "{{SNAP}}/wigwag/etc/versions.json"
    - key: "UPGRADE_VERSIONS_FILE"
      value: "{{SNAP}}/wigwag/etc/versions.json"
+devicedb_conn_config:
+    devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
+    devicedb_prefix: "maestro.configs" #default prefix
+    devicedb_bucket: "lww" #default bucket
+    relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
+    ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name     
 sys_stats: # system stats intervals
   vm_stats:
     every: "15s"

--- a/conf/maestro-conf/edge-config-rpi-production.yaml
+++ b/conf/maestro-conf/edge-config-rpi-production.yaml
@@ -57,6 +57,12 @@ var_defs:
      value: "/mnt/.overlay/user/slash/wigwag/etc/versions.json"
    - key: "UPGRADE_VERSIONS_FILE"
      value: "/mnt/.overlay/upgrade/wigwag/etc/versions.json"
+devicedb_conn_config:
+    devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
+    devicedb_prefix: "maestro.configs" #default prefix
+    devicedb_bucket: "lww" #default bucket
+    relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
+    ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name     
 sys_stats: # system stats intervals
   vm_stats:
     every: "15s"


### PR DESCRIPTION
Add connection config for devicedb, this is required for when maestro cloud based config management is enabled in maestro. Having this config info in yaml files doesnt hurt as it doesnt change anything else.