### PR TITLE
Use the NODE_PATH env variable to locate the developer_identity

### DIFF
--- a/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
+++ b/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
@@ -40,10 +40,10 @@ execute () {
     if [ ! -f ${IDENTITY_DIR}/identity.json -o  "x$internalid" != "x$deviceID"  ]; then
       echo "Creating developer self-signed certificate."
       mkdir -p ${IDENTITY_DIR}
-      if [ -f ${IDENTITY_DIR}/identity.json ] ; then 
+      if [ -f ${IDENTITY_DIR}/identity.json ] ; then
         cp ${IDENTITY_DIR}/identity.json ${IDENTITY_DIR}/identity_original.json
       fi
-      $SCRIPT_DIR/get_new_gw_identity/developer_gateway_identity/bin/create-dev-identity\
+      $NODE_PATH/developer_identity/bin/create-dev-identity\
         -g $lwm2mserveruri\
         -p DEV0\
         -o $OU\

--- a/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
+++ b/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
@@ -19,6 +19,7 @@ WIGWAG_ROOT=${1:-"/wigwag"}
 EDGE_CORE_PORT=${2:-9101}
 IDENTITY_DIR=${3:-/userdata/edge_gw_config}
 SCRIPT_DIR="$WIGWAG_ROOT/wwrelay-utils/debug_scripts"
+PATH=$SCRIPT_DIR/get_new_gw_identity/developer_gateway_identity/bin:$NODE_PATH/developer_identity/bin:$PATH
 
 getEdgeStatus() {
   tmpfile=$(mktemp)
@@ -43,7 +44,7 @@ execute () {
       if [ -f ${IDENTITY_DIR}/identity.json ] ; then
         cp ${IDENTITY_DIR}/identity.json ${IDENTITY_DIR}/identity_original.json
       fi
-      $NODE_PATH/developer_identity/bin/create-dev-identity\
+      create-dev-identity\
         -g $lwm2mserveruri\
         -p DEV0\
         -o $OU\


### PR DESCRIPTION
On snap-pelion-edge the developer_identity is installed on a different path. NODE_PATH should be defined prior to invoking the script inorder for the script to locate the developer_identity scripts. This is required to fix the snap-pelion-edge update - https://github.com/armPelionEdge/snap-pelion-edge/pull/62