### PR TITLE
disabling sys_stats

### DIFF
--- a/conf/maestro-conf/edge-config-rpi-production.yaml
+++ b/conf/maestro-conf/edge-config-rpi-production.yaml
@@ -55,13 +55,6 @@ devicedb_conn_config:
     devicedb_bucket: "lww" #default bucket
     relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
     ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name     
-sys_stats: # system stats intervals
-  vm_stats:
-    every: "15s"
-    name: vm
-  disk_stats:
-    every: "30s"
-    name: disk
 mdns:
   # disable: true
   static_records:

--- a/conf/maestro-conf/edge-config-rpi-production.yaml
+++ b/conf/maestro-conf/edge-config-rpi-production.yaml
@@ -79,7 +79,7 @@ mdns:
 symphony:
 # symphony system management APIs
     # defaults to 10:
-    DisableSysStats: true
+    disable_sys_stats: true
     sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
     sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
     client_cert: "{{ARCH_CLIENT_CERT_PEM}}"

--- a/conf/maestro-conf/edge-config-rpi-production.yaml
+++ b/conf/maestro-conf/edge-config-rpi-production.yaml
@@ -79,6 +79,7 @@ mdns:
 symphony:
 # symphony system management APIs
     # defaults to 10:
+    DisableSysStats: true
     sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
     sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
     client_cert: "{{ARCH_CLIENT_CERT_PEM}}"


### PR DESCRIPTION
According to Ed, sysstats (maestro) needs to be disabled as currently there is no UI for it and it is creating a lot of warning messages on gateway logs in the portal.