### PR TITLE
identity-tool: in prod mode regain the serial number in identity.json

### DIFF
--- a/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
+++ b/debug_scripts/create-new-eeprom-with-self-signed-certs.sh
@@ -33,6 +33,7 @@ getEdgeStatus() {
 readEeprom() {
   if [ -f ${IDENTITY_DIR}/identity.json ] ; then
     deviceID=$(jq -r .deviceID ${IDENTITY_DIR}/identity.json)
+    serialNumber=$(jq -r .serialNumber ${IDENTITY_DIR}/identity.json)
   fi
 }
 
@@ -50,6 +51,7 @@ execute () {
         -g $lwm2mserveruri\
         -p DEV0\
         -o $OU\
+        -s $serialNumber\
         --temp-cert-dir $(mktemp -d)\
         --identity-dir ${IDENTITY_DIR}\
         --internal-id $internalid

--- a/debug_scripts/get_new_gw_identity/developer_gateway_identity/index.js
+++ b/debug_scripts/get_new_gw_identity/developer_gateway_identity/index.js
@@ -30,6 +30,7 @@ program
   .option('-g, --gatewayServicesAddress []', 'The gateway services API address')
   .option('-a, --apiServerAddress []', 'API server address')
   .option('-p, --serialNumberPrefix []', 'Serial Number Prefix')
+  .option('-s, --serialNumber []', 'Gateway serial number')
   .option('-o, --organizationUnit []', 'Account ID', uuid.v4().replace(/-/g, ""))
   .option('--temp-cert-dir []', 'Directory that contains the temporary certs', './temp_certs')
   .option('--script-dir []', 'Directory that contains the generate_self_signed_certs.sh script', '.')
@@ -176,7 +177,9 @@ const run = async() => {
     let identity_obj = {};
 
     let currentSerialNumber = crypto.randomBytes(2).readUInt16BE(0, true);
-    identity_obj.serialNumber = IDGenerator.SerialIDGenerator(program.serialNumberPrefix || 'SOFT', currentSerialNumber, currentSerialNumber + 1);
+    identity_obj.serialNumber = typeof program.serialNumber == 'string' ?
+                                    program.serialNumber :
+                                    IDGenerator.SerialIDGenerator(program.serialNumberPrefix || 'SOFT', currentSerialNumber, currentSerialNumber + 1);
     identity_obj.OU = program.organizationUnit;
     identity_obj.deviceID = program.internalId;
     identity_obj.hardwareVersion = "rpi3bplus";


### PR DESCRIPTION
In production flow, serial number is provided by FCU or pep tool, we should
regain the same serial number when generating a new identity.json with OU and
deviceID.