### PR TITLE
Disable network management for the dell5000

### DIFF
--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -89,7 +89,7 @@ symphony:
     url_stats: "{{ARCH_GW_SERVICES_URL}}/relay-stats/stats_obj"
     # port: "{{ARCH_RELAY_SERVICES_PORT}}"
 targets:
-   - file: "/tmp/devicejs.log"
+   - file: "/var/snap/pelion-edge/current/userdata/maestro.log"
      rotate:
          max_files: 4
          max_file_size: 10000000  # 10MB max file size

--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -13,7 +13,7 @@ processes:
 platform_readers:
   - platform: "fsonly"
     params:
-      identityPath: "/var/snap/pelion-edge/current/userdata/edge_gw_config/identity.json"
+      identityPath: "/var/snap/pelion-edge/current/userdata/edge_gw_identity/identity.json"
 var_defs:
    - key: "SNAP_DATA"
      value: "/var/snap/pelion-edge/current"
@@ -30,7 +30,7 @@ var_defs:
    - key: "MAESTRO_RUNNER_DIR"
      value: "{{SNAP}}/wigwag/devicejs-core-modules/maestroRunner"
    - key: "SSL_CERTS_PATH"
-     value: "{{SNAP_DATA}}/userdata/edge_gw_config/.ssl"
+     value: "{{SNAP_DATA}}/userdata/edge_gw_identity/.ssl"
    - key: "LOCAL_DEVICEDB_PORT"
      value: 9000
    - key: "LOCAL_DATABASE_STORAGE_DIRECTORY"

--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -7,11 +7,7 @@ imagePath: /tmp/maestro/images
 scratchPath: /tmp/maestro/scratch
 clientId: "{{ARCH_SERIAL_NUMBER}}"
 network:
-    interfaces:
-        - if_name: eth0
-          dhcpv4: true
-          # set the mac addresses for this interface also:
-          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+    disable: true
 processes:
     reaper_interval: 1500
 platform_readers:


### PR DESCRIPTION
Network management will occur via the NMCLI for this specific target
instead of using maestro.