### PR TITLE
Use fpedge

### DIFF
--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -80,13 +80,15 @@ mdns:
 symphony:
 # symphony system management APIs
     # defaults to 10:
+    disable_sys_stats: true
     sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
     sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
-    client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
-    client_key: "{{ARCH_CLIENT_KEY_PEM}}"
-    host: "{{ARCH_GW_SERVICES_RESRC}}"
-    url_logs: "{{ARCH_GW_SERVICES_URL}}/relay-logs/logs"
-    url_stats: "{{ARCH_GW_SERVICES_URL}}/relay-stats/stats_obj"
+    #client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
+    #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
+    no_tls: true
+    host: "gateways.local"
+    url_logs: "http://gateways.local:8080/relay-logs/logs"
+    url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
     # port: "{{ARCH_RELAY_SERVICES_PORT}}"
 targets:
    - file: "/var/snap/pelion-edge/current/userdata/maestro.log"

--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -43,19 +43,12 @@ var_defs:
      value: "{{SNAP}}/wigwag/etc/versions.json"
    - key: "UPGRADE_VERSIONS_FILE"
      value: "{{SNAP}}/wigwag/etc/versions.json"
-# devicedb_conn_config:
-#   devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
-#   devicedb_prefix: "maestro.configs" #default prefix
-#   devicedb_bucket: "lww" #default bucket
-#   relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
-#   ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name
-sys_stats: # system stats intervals
-  vm_stats:
-    every: "15s"
-    name: vm
-  disk_stats:
-    every: "30s"
-    name: disk
+devicedb_conn_config:
+  devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
+  devicedb_prefix: "maestro.configs" #default prefix
+  devicedb_bucket: "lww" #default bucket
+  relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
+  ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name
 mdns:
   # disable: true
   static_records:

--- a/conf/maestro-conf/relayTerm.template.json
+++ b/conf/maestro-conf/relayTerm.template.json
@@ -1,6 +1,6 @@
 {
-	"cloud": "{{ARCH_GW_SERVICES_URL}}/relay-term",
+	"cloud": "http://gateways.local:8080/relay-term",
 	"noValidate": true,
-	"certificate": "{{SSL_CERTS_PATH}}/client.cert.pem",
-	"key": "{{SSL_CERTS_PATH}}/client.key.pem"
+	"certificate": "",
+	"key": ""
 }

--- a/conf/maestro-conf/template.devicedb.conf
+++ b/conf/maestro-conf/template.devicedb.conf
@@ -165,7 +165,7 @@ cloud:
     # effectively ignored. In this example, the TLS certificate uses a wildcard
     # certificate so the server name provided in the certificate will not
     # match the domain name of the host to which this node is connecting.
-    uri: wss://{{ARCH_GW_SERVICES_RESRC}}/devicedb/sync
+    uri: ws://gateways.local:8080/devicedb/sync
 
     # Starting in version 1.3.0 of devicedb a seperate host name, port, and certificate
     # name can be specified for historical data forwarding. This is to allow decoupling
@@ -182,8 +182,8 @@ cloud:
     # historyID: "*.wigwag.io"
     # historyHost and historyPort may be ommitted. In this case historyHost and
     # historyPort are set to the normal cloud host and port
-    historyURI: {{ARCH_GW_SERVICES_URL}}/relay-history/history
-    alertsURI: {{ARCH_GW_SERVICES_URL}}/relay-alerts/alerts
+    historyURI: gateways.local:8080/relay-history/history
+    alertsURI: gateways.local:8080/relay-alerts/alerts
 
 # The TLS options specify file paths to PEM encoded SSL certificates and keys
 # All connections between database nodes use TLS to identify and authenticate
@@ -198,7 +198,8 @@ cloud:
 # node but does need to verify the database node's server certificate against
 # the same root certificate chain.
 # **REQUIRED**
-tls:
+nodeid: {{ARCH_DEVICE_ID}}
+#tls:
     # If using a single certificate for both client and server authentication
     # then it is specified using the certificate and key options as shown below
     # If using seperate client and server certificates then uncomment the options
@@ -212,17 +213,17 @@ tls:
     # key: path/to/key.pem
     
     # A PEM encoded 'client' type certificate
-    clientCertificate: {{SSL_CERTS_PATH}}/client.cert.pem
+    #clientCertificate: {{SSL_CERTS_PATH}}/client.cert.pem
     
     # A PEM encoded key corresponding to the specified client certificate
-    clientKey: {{SSL_CERTS_PATH}}/client.key.pem
+    #clientKey: {{SSL_CERTS_PATH}}/client.key.pem
     
     # A PEM encoded 'server' type certificate
-    serverCertificate: {{SSL_CERTS_PATH}}/server.cert.pem
+    #serverCertificate: {{SSL_CERTS_PATH}}/server.cert.pem
     
     # A PEM encoded key corresponding to the specified server certificate
-    serverKey: {{SSL_CERTS_PATH}}/server.key.pem
+    #serverKey: {{SSL_CERTS_PATH}}/server.key.pem
     
     # A PEM encoded certificate chain that can be used to verify the previous
     # certificates
-    rootCA: {{SSL_CERTS_PATH}}/ca-chain.cert.pem
+    #rootCA: {{SSL_CERTS_PATH}}/ca-chain.cert.pem


### PR DESCRIPTION
This PR changes default config of relay-term, devicedb and maestro so that these services can talk to cloud without self signed certificates through fp-edge.
Also, it disables systats in maestro since there is no need to send these stats.