### PR TITLE
dell5000: connect to devicedb over http not https

### DIFF
--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -44,7 +44,7 @@ var_defs:
    - key: "UPGRADE_VERSIONS_FILE"
      value: "{{SNAP}}/wigwag/etc/versions.json"
 devicedb_conn_config:
-  devicedb_uri: "https://{{ARCH_DEVICE_ID}}:9000" #default uri
+  devicedb_uri: "http://{{ARCH_DEVICE_ID}}:9000" #default uri
   devicedb_prefix: "maestro.configs" #default prefix
   devicedb_bucket: "lww" #default bucket
   relay_id: "{{ARCH_DEVICE_ID}}" #default relay id


### PR DESCRIPTION
TLS support in devicedb was disabled with commit
f2ce3c854570ae4955c149ddaab54650b1db2d5d, so maestro should
connect to devicedb with http and not https.