### PR TITLE
Change the devicedb prefix

### DIFF
--- a/conf/maestro-conf/edge-config-dell5000-demo.yaml
+++ b/conf/maestro-conf/edge-config-dell5000-demo.yaml
@@ -45,7 +45,7 @@ var_defs:
      value: "{{SNAP}}/wigwag/etc/versions.json"
 devicedb_conn_config:
   devicedb_uri: "http://{{ARCH_DEVICE_ID}}:9000" #default uri
-  devicedb_prefix: "maestro.configs" #default prefix
+  devicedb_prefix: "configs.device" #default prefix
   devicedb_bucket: "lww" #default bucket
   relay_id: "{{ARCH_DEVICE_ID}}" #default relay id
   ca_chain: "{{SSL_CERTS_PATH}}/ca-chain.cert.pem" #default chain cert file name


### PR DESCRIPTION
Match the DeviceDB Cloud prefix to allow us to use the DeviceDB Cloud Pelion REST APIs.