### PR TITLE
Fix integration lab

### DIFF
--- a/debug_scripts/get_new_gw_identity/developer_gateway_identity/index.js
+++ b/debug_scripts/get_new_gw_identity/developer_gateway_identity/index.js
@@ -151,7 +151,7 @@ function findEdgeK8sServiceAddressFromMDS(server_uri) {
 function findServiceAddressFromMDS(server_uri, service_name) {
 
     var integrationLab = /.*mds-integration-lab.*/;
-    var newIntegrationLab = /.*lwm2m-integration-lab.*/;
+    var newIntegrationLab = /.*lwm2m.*integration-lab.*/;
 
     var sysTest4 = /.*mds-syte4-sandbox.*/;
 


### PR DESCRIPTION
Update the regex which matches integration lab to allow anything to come  between "lwm2m" and "integration-lab" in the URL sent during bootstrap. This allows new style URLs to be properly matched. For example:

- coaps://lwm2m-udp-integration-lab.mbedcloudintegration.net
- coaps://lwm2m-tcp-integration-lab.mbedcloudintegration.net